### PR TITLE
apply: email confirmation

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,6 +35,7 @@ env_to_conf_entries = [
     ("SERVER_BASEURL", "server", "base_url"),
     ("SERVER_TORNADO", "server", "use_tornado"),
     ("SERVER_LOGFILE", "server", "logfile"),
+    ("SERVER_PASSWORD_SALT", "server", "password_salt"),
     #
     ("ACCEPT_APPLICATIONS", "application", "accept_applications"),
     #

--- a/confirmation_token.py
+++ b/confirmation_token.py
@@ -1,0 +1,21 @@
+import hashlib
+from __init__ import *
+from config import conf
+
+from itsdangerous import URLSafeSerializer
+
+def generate_confirmation_token(email):
+    serializer = URLSafeSerializer(conf.get('server', 'secret'))
+    return serializer.dumps(email, salt=conf.get('server', 'password_salt') + conf.get('application', 'shortname'))
+
+
+def confirm_token(token):
+    serializer = URLSafeSerializer(conf.get('server', 'secret'))
+    try:
+        email = serializer.loads(
+            token,
+            salt=conf.get('server', 'password_salt') + conf.get('application', 'shortname')
+        )
+    except:
+        return False
+    return email

--- a/ehb-empty.sql
+++ b/ehb-empty.sql
@@ -1,11 +1,11 @@
 -- phpMyAdmin SQL Dump
--- version 4.7.7
+-- version 4.8.3
 -- https://www.phpmyadmin.net/
 --
 -- Host: mysql
--- Generation Time: Feb 21, 2018 at 10:57 AM
+-- Generation Time: Jan 22, 2019 at 10:22 PM
 -- Server version: 5.7.20
--- PHP Version: 7.1.9
+-- PHP Version: 7.2.8
 
 SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 SET AUTOCOMMIT = 0;
@@ -523,7 +523,8 @@ CREATE TABLE `participant` (
   `code` varchar(16) DEFAULT NULL,
   `member` tinyint(1) NOT NULL,
   `discounted` varchar(8) DEFAULT NULL,
-  `final_fee` int(11) DEFAULT NULL
+  `final_fee` int(11) DEFAULT NULL,
+  `confirmed` tinyint(1) NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- --------------------------------------------------------

--- a/tables.py
+++ b/tables.py
@@ -79,6 +79,7 @@ class Participant(Base):
     donation = Column(Integer)
     discounted = Column(String(8))
     final_fee = Column(Integer)
+    confirmed = Column(Boolean)
 
     iq_username = Column(String(100))
     code = Column(String(16))

--- a/templates/application_confirm_email.txt
+++ b/templates/application_confirm_email.txt
@@ -1,0 +1,11 @@
+Dear {{ prt.fullname() }},
+
+Thank you for applying to {{ eventname }}!
+
+To complete your application, please confirm your email address and make your
+Paypal payment of {{ currency_symbol }} {{ amount }} by following this link:
+
+{{ confirmation_url }}
+
+With kind regards,
+{{ shortname }} Organizers

--- a/templates/apply.html
+++ b/templates/apply.html
@@ -106,7 +106,7 @@
         {{ m.header("section5", """<strong>Important:</strong> By clicking on the \"Submit\" button below, you apply for participation in the
         " + conf_data["name"] + ".
         <strong>Please review your data carefully before clicking the button; you will not have a chance to change it later.</strong> When you click on
-        \"Submit\", we will redirect you to Paypal, where you will be asked to pay the registration fee of € " + conf_data["s_application_fee"] + ", plus your sponsorship
+        \"Submit\", you will receive an email with a link to get to Paypal, where you will be asked to pay the registration fee of € " + conf_data["s_application_fee"] + ", plus your sponsorship
         donation if you made one. The recipient is
         \"BinG Barbershop in Germany\".""") }}
 

--- a/templates/confirm.html
+++ b/templates/confirm.html
@@ -1,0 +1,51 @@
+{% extends "main.html" %}
+{% import "macros.html" as m %}
+
+{% block content %}
+
+{% with messages = get_flashed_messages() %}
+    {% if messages %}
+        {% for message in messages %}
+            <hr/> <p class="error"> {{ message }} </p>
+        {% endfor %}
+    {% endif %}
+{% endwith %}
+
+
+<div class="page-header"> <h1>Executing your payment</h1> </div>
+
+
+<div>
+<p>
+Hello, {{ prt.firstname }} {{ prt.lastname }}!
+</p>
+
+{% if total_amount > 0 %}
+    <p>On this page, you can complete your payment for {{ conf_data["shortname"] }}.
+    </p>
+
+    <p>Our records show that you still need to pay for the following items:</p>
+
+    <table class="table">
+        {% for item in payment_items %}
+          <tr><td>{{ item.name }}</td>  <td>€ {{ item.amount }}</td></tr>
+        {% endfor %}
+
+        <tr><td><strong>Total:</strong></td>  <td><strong>€ {{ total_amount }}</strong></td></tr>
+    </table>
+
+    <p>Please click on the "Execute Payment" button below to execute this payment. Thank you!</p>
+
+        <form class="form-horizontal" action="{{ url_for('doExecutePaymentOops') }}" method="post">
+            <input type="hidden" name="id" value="{{ prt.id }}">
+            <input type="hidden" name="amount" value="{{ total_amount }}">
+            <button id="submit" name="submit" type="submit" class="btn btn-primary">Execute Payment</button>
+        </form>
+
+{% else %}
+<p>You have completed all of your payments. Thank you!</p>
+{% endif %}
+</div>
+
+
+{% endblock %}

--- a/templates/confirmation_email_sent.html
+++ b/templates/confirmation_email_sent.html
@@ -1,0 +1,18 @@
+{% extends "main.html" %}
+{% import "macros.html" as m %}
+
+{% block content %}
+
+	<p>You have successfully submitted your application to the {{ name }}.
+		Please note, that in order to complete this process you have to confirm
+    your email address by clicking the link in the email you should receive
+    from us. In this step you also have to make the payment of {{ currency_symbol }} {{ amount }} via Paypal.
+	</p>
+
+    <p><a href="http://www.europeanharmonybrigade.org/">Click here to return to the main EHB website.</a></p>
+
+	<hr/>
+
+    {% include "participant_details.html" %}
+
+{% endblock %}

--- a/templates/payment_confirmation.html
+++ b/templates/payment_confirmation.html
@@ -17,7 +17,7 @@
 		</p>
 
 
-    <p>Please print or save this page for your records. You will not receive an e-mail confirmation of your payment from us.</p>
+    <p>Please print or save this page for your records. You will not receive an email confirmation of your payment from us.</p>
 
     <p><a href="http://www.europeanharmonybrigade.org/">Click here to return to the main EHB website.</a></p>
 


### PR DESCRIPTION
Add an email confirmation step to the application process. This way, the user
only has to pay after the account has been successfully created (duplicate
email).
Also, they can come back to the payment page later, if they wish to.

Signed-off-by: Martin Kaistra <admin@djfun.de>